### PR TITLE
measure throughput

### DIFF
--- a/DAS/__init__.py
+++ b/DAS/__init__.py
@@ -1,1 +1,3 @@
 from DAS.simulator import *
+from DAS.configuration import *
+from DAS.shape import *

--- a/DAS/block.py
+++ b/DAS/block.py
@@ -9,8 +9,8 @@ class Block:
     blockSize = 0
     data = bitarray()
 
-    def __init__(self, size):
-        self.blockSize = size
+    def __init__(self, blockSize):
+        self.blockSize = blockSize
         self.data = zeros(self.blockSize*self.blockSize)
 
     def fill(self):

--- a/DAS/configuration.py
+++ b/DAS/configuration.py
@@ -1,0 +1,48 @@
+#!/bin/python3
+
+import configparser
+
+class Configuration:
+
+    deterministic = 0
+
+    def __init__(self, fileName):
+
+        config = configparser.RawConfigParser()
+        config.read(fileName)
+
+        self.nvStart = int(config.get("Simulation Space", "numberValidatorStart"))
+        self.nvStop = int(config.get("Simulation Space", "numberValidatorStop"))
+        self.nvStep = int(config.get("Simulation Space", "numberValidatorStep"))
+
+        self.blockSizeStart = int(config.get("Simulation Space", "blockSizeStart"))
+        self.blockSizeStop = int(config.get("Simulation Space", "blockSizeStop"))
+        self.blockSizeStep = int(config.get("Simulation Space", "blockSizeStep"))
+
+        self.netDegreeStart = int(config.get("Simulation Space", "netDegreeStart"))
+        self.netDegreeStop = int(config.get("Simulation Space", "netDegreeStop"))
+        self.netDegreeStep = int(config.get("Simulation Space", "netDegreeStep"))
+
+        self.failureRateStart = int(config.get("Simulation Space", "failureRateStart"))
+        self.failureRateStop = int(config.get("Simulation Space", "failureRateStop"))
+        self.failureRateStep = int(config.get("Simulation Space", "failureRateStep"))
+
+        self.chiStart = int(config.get("Simulation Space", "chiStart"))
+        self.chiStop = int(config.get("Simulation Space", "chiStop"))
+        self.chiStep = int(config.get("Simulation Space", "chiStep"))
+
+        self.numberRuns = int(config.get("Advanced", "numberRuns"))
+        self.deterministic = config.get("Advanced", "deterministic")
+
+        if self.nvStop < (self.blockSizeStart*4):
+            print("ERROR: The number of validators cannot be lower than the block size * 4")
+            exit(1)
+        if self.chiStart < 1:
+            print("Chi has to be greater than 0")
+            exit(1)
+        if self.chiStop > self.blockSizeStart:
+            print("Chi (%d) has to be smaller or equal to block the size (%d)" % (self.chiStop, self.blockSizeStart))
+            exit(1)
+
+
+

--- a/DAS/observer.py
+++ b/DAS/observer.py
@@ -5,40 +5,40 @@ from DAS.block import *
 class Observer:
 
     block = []
-    blockSize = 0
     rows = []
     columns = []
     goldenData = []
     broadcasted = []
+    config = []
     logger = []
 
-    def __init__(self, blockSize, logger):
+    def __init__(self, logger, config):
+        self.config = config
         self.format = {"entity": "Observer"}
-        self.blockSize = blockSize
         self.logger = logger
 
     def reset(self):
-        self.block = [0] * self.blockSize * self.blockSize
-        self.goldenData = [0] * self.blockSize * self.blockSize
-        self.rows = [0] * self.blockSize
-        self.columns = [0] * self.blockSize
-        self.broadcasted = Block(self.blockSize)
+        self.block = [0] * self.config.blockSize * self.config.blockSize
+        self.goldenData = [0] * self.config.blockSize * self.config.blockSize
+        self.rows = [0] * self.config.blockSize
+        self.columns = [0] * self.config.blockSize
+        self.broadcasted = Block(self.config.blockSize)
 
     def checkRowsColumns(self, validators):
         for val in validators:
-            if val.proposer == 0:
+            if val.amIproposer == 0:
                 for r in val.rowIDs:
                     self.rows[r] += 1
                 for c in val.columnIDs:
                     self.columns[c] += 1
 
-        for i in range(self.blockSize):
+        for i in range(self.config.blockSize):
             self.logger.debug("Row/Column %d have %d and %d validators assigned." % (i, self.rows[i], self.columns[i]), extra=self.format)
             if self.rows[i] == 0 or self.columns[i] == 0:
                 self.logger.warning("There is a row/column that has not been assigned", extra=self.format)
 
     def setGoldenData(self, block):
-        for i in range(self.blockSize*self.blockSize):
+        for i in range(self.config.blockSize*self.config.blockSize):
             self.goldenData[i] = block.data[i]
 
     def checkBroadcasted(self):
@@ -54,7 +54,7 @@ class Observer:
         arrived = 0
         expected = 0
         for val in validators:
-            if val.proposer == 0:
+            if val.amIproposer == 0:
                 (a, e) = val.checkStatus()
                 arrived += a
                 expected += e

--- a/DAS/results.py
+++ b/DAS/results.py
@@ -1,0 +1,17 @@
+#!/bin/python3
+
+
+class Result:
+
+    config = []
+    missingVector = []
+    blockAvailable = -1
+
+    def __init__(self, config):
+        self.config = config
+        self.blockAvailable = -1
+        self.missingVector = []
+
+
+    def addMissing(self, missingVector):
+        self.missingVector = missingVector

--- a/DAS/shape.py
+++ b/DAS/shape.py
@@ -1,0 +1,19 @@
+#!/bin/python3
+
+class Shape:
+    numberValidators = 0
+    failureRate = 0
+    blockSize = 0
+    netDegree = 0
+    chi = 0
+
+    def __init__(self, blockSize, numberValidators, failureRate, chi, netDegree):
+        self.numberValidators = numberValidators
+        self.failureRate = failureRate
+        self.blockSize = blockSize
+        self.netDegree = netDegree
+        self.chi = chi
+
+
+
+

--- a/DAS/simulator.py
+++ b/DAS/simulator.py
@@ -61,8 +61,8 @@ class Simulator:
             for u, v in G.edges:
                 val1=rowChannels[id][u]
                 val2=rowChannels[id][v]
-                val1.rowNeighbors[id].append(Neighbor(val2))
-                val2.rowNeighbors[id].append(Neighbor(val1))
+                val1.rowNeighbors[id].update({val2.ID : Neighbor(val2, self.shape.blockSize)})
+                val2.rowNeighbors[id].update({val1.ID : Neighbor(val1, self.shape.blockSize)})
 
             if (len(columnChannels[id]) < self.shape.netDegree):
                 self.logger.error("Graph degree higher than %d" % len(columnChannels[id]), extra=self.format)
@@ -72,8 +72,8 @@ class Simulator:
             for u, v in G.edges:
                 val1=columnChannels[id][u]
                 val2=columnChannels[id][v]
-                val1.columnNeighbors[id].append(Neighbor(val2))
-                val2.columnNeighbors[id].append(Neighbor(val1))
+                val1.columnNeighbors[id].update({val2.ID : Neighbor(val2, self.shape.blockSize)})
+                val2.columnNeighbors[id].update({val1.ID : Neighbor(val1, self.shape.blockSize)})
 
     def initLogger(self):
         logger = logging.getLogger("DAS")

--- a/DAS/simulator.py
+++ b/DAS/simulator.py
@@ -111,6 +111,8 @@ class Simulator:
                 self.validators[i].sendColumns()
                 self.validators[i].logRows()
                 self.validators[i].logColumns()
+            for i in range(0,self.numberValidators):
+                self.validators[i].updateStats()
 
             arrived, expected = self.glob.checkStatus(self.validators)
             missingSamples = expected - arrived

--- a/DAS/simulator.py
+++ b/DAS/simulator.py
@@ -61,8 +61,8 @@ class Simulator:
             for u, v in G.edges:
                 val1=rowChannels[id][u]
                 val2=rowChannels[id][v]
-                val1.rowNeighbors[id].append(val2)
-                val2.rowNeighbors[id].append(val1)
+                val1.rowNeighbors[id].append(Neighbor(val2))
+                val2.rowNeighbors[id].append(Neighbor(val1))
 
             if (len(columnChannels[id]) < self.shape.netDegree):
                 self.logger.error("Graph degree higher than %d" % len(columnChannels[id]), extra=self.format)
@@ -72,8 +72,8 @@ class Simulator:
             for u, v in G.edges:
                 val1=columnChannels[id][u]
                 val2=columnChannels[id][v]
-                val1.columnNeighbors[id].append(val2)
-                val2.columnNeighbors[id].append(val1)
+                val1.columnNeighbors[id].append(Neighbor(val2))
+                val2.columnNeighbors[id].append(Neighbor(val1))
 
     def initLogger(self):
         logger = logging.getLogger("DAS")

--- a/DAS/simulator.py
+++ b/DAS/simulator.py
@@ -99,19 +99,20 @@ class Simulator:
         missingSamples = expected - arrived
         missingVector = []
         steps = 0
-        while(missingSamples > 0):
+        while(True):
             missingVector.append(missingSamples)
             oldMissingSamples = missingSamples
+            for i in range(0,self.shape.numberValidators):
+                self.validators[i].sendRows()
+                self.validators[i].sendColumns()
             for i in range(1,self.shape.numberValidators):
                 self.validators[i].receiveRowsColumns()
             for i in range(1,self.shape.numberValidators):
                 self.validators[i].restoreRows()
                 self.validators[i].restoreColumns()
-                self.validators[i].sendRows()
-                self.validators[i].sendColumns()
+            for i in range(0,self.shape.numberValidators):
                 self.validators[i].logRows()
                 self.validators[i].logColumns()
-            for i in range(0,self.numberValidators):
                 self.validators[i].updateStats()
 
             arrived, expected = self.glob.checkStatus(self.validators)

--- a/DAS/validator.py
+++ b/DAS/validator.py
@@ -89,14 +89,14 @@ class Validator:
                     self.block.data[i] = 1
                 else:
                     self.block.data[i] = 0
+
+            self.changedRow = {id:True for id in self.rowIDs}
+            self.changedColumn = {id:True for id in self.columnIDs}
+
             nbFailures = self.block.data.count(0)
             measuredFailureRate = nbFailures * 100 / (self.shape.blockSize * self.shape.blockSize)
             self.logger.debug("Number of failures: %d (%0.02f %%)", nbFailures, measuredFailureRate, extra=self.format)
             #broadcasted.print()
-            for id in range(self.shape.blockSize):
-                self.sendColumn(id)
-            for id in range(self.shape.blockSize):
-                self.sendRow(id)
 
     def getColumn(self, index):
         return self.block.getColumn(index)
@@ -177,22 +177,16 @@ class Validator:
                     self.statsTxInSlot += toSend.count(1)
 
     def sendRows(self):
-        if self.amIproposer == 1:
-            self.logger.error("I am a block proposer", extra=self.format)
-        else:
-            self.logger.debug("Sending restored rows...", extra=self.format)
-            for r in self.rowIDs:
-                if self.changedRow[r]:
-                    self.sendRow(r)
+        self.logger.debug("Sending restored rows...", extra=self.format)
+        for r in self.rowIDs:
+            if self.changedRow[r]:
+                self.sendRow(r)
 
     def sendColumns(self):
-        if self.amIproposer == 1:
-            self.logger.error("I am a block proposer", extra=self.format)
-        else:
-            self.logger.debug("Sending restored columns...", extra=self.format)
-            for c in self.columnIDs:
-                if self.changedColumn[c]:
-                    self.sendColumn(c)
+        self.logger.debug("Sending restored columns...", extra=self.format)
+        for c in self.columnIDs:
+            if self.changedColumn[c]:
+                self.sendColumn(c)
 
     def logRows(self):
         if self.logger.isEnabledFor(logging.DEBUG):

--- a/DAS/validator.py
+++ b/DAS/validator.py
@@ -10,7 +10,7 @@ from bitarray.util import zeros
 class Neighbor:
 
     def __repr__(self):
-        return str(self.node.ID)
+        return "%d:%d/%d" % (self.node.ID, self.sent.count(1), self.received.count(1))
 
     def __init__(self, v, blockSize):
         self.node = v
@@ -24,6 +24,9 @@ class Validator:
     shape = []
     format = {}
     logger = []
+
+    def __repr__(self):
+        return str(self.ID)
 
     def __init__(self, ID, amIproposer, logger, shape, rows, columns):
         self.shape = shape

--- a/DAS/validator.py
+++ b/DAS/validator.py
@@ -39,6 +39,8 @@ class Validator:
                 #    random.seed(self.ID)
                 #self.rowIDs = random.sample(range(self.shape.blockSize), self.shape.chi)
                 #self.columnIDs = random.sample(range(self.shape.blockSize), self.shape.chi)
+        self.changedRow = {id:False for id in self.rowIDs}
+        self.changedColumn = {id:False for id in self.columnIDs}
         self.rowNeighbors = collections.defaultdict(list)
         self.columnNeighbors = collections.defaultdict(list)
 
@@ -103,6 +105,16 @@ class Validator:
             self.logger.debug("Receiving the data...", extra=self.format)
             #self.logger.debug("%s -> %s", self.block.data, self.receivedBlock.data, extra=self.format)
 
+            self.changedRow = { id:
+                self.getRow(id) != self.receivedBlock.getRow(id)
+                for id in self.rowIDs
+            }
+
+            self.changedColumn = { id:
+                self.getColumn(id) != self.receivedBlock.getColumn(id)
+                for id in self.columnIDs
+            }
+
             self.block.merge(self.receivedBlock)
 
     def sendColumn(self, columnID):
@@ -125,7 +137,8 @@ class Validator:
         else:
             self.logger.debug("Sending restored rows...", extra=self.format)
             for r in self.rowIDs:
-                self.sendRow(r)
+                if self.changedRow[r]:
+                    self.sendRow(r)
 
     def sendColumns(self):
         if self.amIproposer == 1:
@@ -133,7 +146,8 @@ class Validator:
         else:
             self.logger.debug("Sending restored columns...", extra=self.format)
             for c in self.columnIDs:
-                self.sendColumn(c)
+                if self.changedColumn[c]:
+                    self.sendColumn(c)
 
     def logRows(self):
         if self.logger.isEnabledFor(logging.DEBUG):

--- a/DAS/validator.py
+++ b/DAS/validator.py
@@ -7,6 +7,14 @@ from DAS.block import *
 from bitarray import bitarray
 from bitarray.util import zeros
 
+class Neighbor:
+
+    def __repr__(self):
+        return str(self.node.ID)
+
+    def __init__(self, v):
+        self.node = v
+
 class Validator:
 
     ID = 0
@@ -122,14 +130,14 @@ class Validator:
         if line.any():
             self.logger.debug("col %d -> %s", columnID, self.columnNeighbors[columnID] , extra=self.format)
             for n in self.columnNeighbors[columnID]:
-                n.receiveColumn(columnID, line)
+                n.node.receiveColumn(columnID, line)
 
     def sendRow(self, rowID):
         line = self.getRow(rowID)
         if line.any():
             self.logger.debug("row %d -> %s", rowID, self.rowNeighbors[rowID], extra=self.format)
             for n in self.rowNeighbors[rowID]:
-                n.receiveRow(rowID, line)
+                n.node.receiveRow(rowID, line)
 
     def sendRows(self):
         if self.amIproposer == 1:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# DAS Research 
+# DAS Research
 
-This repository hosts all the research on DAS for the collaboration between Codex and the EF. 
+This repository hosts all the research on DAS for the collaboration between Codex and the EF.
 
 ## Prepare the environment
 
@@ -16,11 +16,11 @@ $ cd das-research
 ```
 $ python3 -m venv myenv
 $ source myenv/bin/activate
-$ pip3 install -r DAS/requeriments.txt
+$ pip3 install -r DAS/requirements.txt
 ```
 
 ## Run the simulator
 
 ```
-$ python3 study.py
+$ python3 study.py config.das
 ```

--- a/config.das
+++ b/config.das
@@ -1,0 +1,27 @@
+[Simulation Space]
+
+numberValidatorStart = 256
+numberValidatorStop  = 512
+numberValidatorStep  = 128
+
+failureRateStart = 10
+failureRateStop  = 90
+failureRateStep  = 40
+
+blockSizeStart = 32
+blockSizeStop  = 64
+blockSizeStep  = 16
+
+netDegreeStart = 6
+netDegreeStop  = 8
+netDegreeStep  = 1
+
+chiStart = 4
+chiStop  = 8
+chiStep  = 2
+
+
+[Advanced]
+
+deterministic = 0
+numberRuns = 2

--- a/study.py
+++ b/study.py
@@ -1,35 +1,45 @@
 #! /bin/python3
 
-import time
+import time, sys
 from DAS import *
 
 
 def study():
-    sim = Simulator(0)
+    if len(sys.argv) < 2:
+        print("You need to pass a configuration file in parameter")
+        exit(1)
+
+    config = Configuration(sys.argv[1])
+    sim = Simulator(config)
     sim.initLogger()
-    maxTries = 10
-    step = 20
-    frRange = []
-    resultRange = []
+    results = []
     simCnt = 0
+
     sim.logger.info("Starting simulations:", extra=sim.format)
     start = time.time()
-    for fr in range(0, 100, step):
-        if fr % 10 == 0:
-            sim.logger.info("Failure rate %d %% ..." % fr, extra=sim.format)
-        sim.resetFailureRate(fr)
-        result = 0
-        for i in range(maxTries):
-            sim.initValidators()
-            sim.initNetwork()
-            result += sim.run()
-            simCnt += 1
-        frRange.append(fr)
-        resultRange.append((maxTries-result)*100/maxTries)
+
+    for run in range(config.numberRuns):
+        for fr in range(config.failureRateStart, config.failureRateStop+1, config.failureRateStep):
+            for chi in range(config.chiStart, config.chiStop+1, config.chiStep):
+                for blockSize in range(config.blockSizeStart, config.blockSizeStop+1, config.blockSizeStep):
+                    for nv in range(config.nvStart, config.nvStop+1, config.nvStep):
+                        for netDegree in range(config.netDegreeStart, config.netDegreeStop+1, config.netDegreeStep):
+
+                            if not config.deterministic:
+                                random.seed(datetime.now())
+
+                            shape = Shape(blockSize, nv, fr, chi, netDegree)
+                            sim.resetShape(shape)
+                            sim.initValidators()
+                            sim.initNetwork()
+                            result = sim.run()
+                            sim.logger.info("Run %d, FR: %d %%, Chi: %d, BlockSize: %d, Nb.Val: %d, netDegree: %d ... Block Available: %d" % (run, fr, chi, blockSize, nv, netDegree, result.blockAvailable), extra=sim.format)
+                            results.append(result)
+                            simCnt += 1
+
     end = time.time()
     sim.logger.info("A total of %d simulations ran in %d seconds" % (simCnt, end-start), extra=sim.format)
-    for i in range(len(frRange)):
-        sim.logger.info("For failure rate of %d we got %d %% success rate in DAS!" % (frRange[i], resultRange[i]), extra=sim.format)
+
 
 
 study()


### PR DESCRIPTION
Add per neighbor state and use it for throughput statistics

This PR adds:
- Neighbor class to keep per neighbor state of sent and received segments to avoid double send and sending back (this was not a problem before while using binary or, but we need more precision to count throughput.
- Collection of tx and rx throughput statistics per node and per timeslot.
- Fix to the initial timestep, that previously included 2 steps in 1.
