### PR TITLE
Changing the success condition

### DIFF
--- a/DAS/results.py
+++ b/DAS/results.py
@@ -21,7 +21,9 @@ class Result:
         self.shape = shape
         self.missingVector = missingVector
         missingSamples = missingVector[-1]
-        if missingSamples == 0:
+        validatorsReady = self.metrics["progress"]["validators ready"][-1]
+        #print("There are %05.3f%% validators ready" % (validatorsReady*100))
+        if validatorsReady > config.successCondition:
             self.blockAvailable = 1
             self.tta = len(missingVector) * (config.stepDuration)
         else:

--- a/DAS/results.py
+++ b/DAS/results.py
@@ -23,7 +23,7 @@ class Result:
         self.missingVector = missingVector
         v = self.metrics["progress"]["validators ready"]
         tta = bisect.bisect(v, config.successCondition)
-        if tta != len(v):
+        if v[-1] >= config.successCondition:
             self.blockAvailable = 1
             self.tta = tta * (config.stepDuration)
         else:

--- a/DAS/results.py
+++ b/DAS/results.py
@@ -1,6 +1,7 @@
 #!/bin/python3
 
 import os
+import bisect
 from xml.dom import minidom
 from dicttoxml import dicttoxml
 
@@ -20,12 +21,11 @@ class Result:
         """It populates part of the result data inside a vector."""
         self.shape = shape
         self.missingVector = missingVector
-        missingSamples = missingVector[-1]
-        validatorsReady = self.metrics["progress"]["validators ready"][-1]
-        #print("There are %05.3f%% validators ready" % (validatorsReady*100))
-        if validatorsReady > config.successCondition:
+        v = self.metrics["progress"]["validators ready"]
+        tta = bisect.bisect(v, config.successCondition)
+        if tta != len(v):
             self.blockAvailable = 1
-            self.tta = len(missingVector) * (config.stepDuration)
+            self.tta = tta * (config.stepDuration)
         else:
             self.blockAvailable = 0
             self.tta = -1

--- a/config_example.py
+++ b/config_example.py
@@ -76,6 +76,9 @@ randomSeed = "DAS"
 # Number of steps without progress to stop simulation
 steps4StopCondition = 7
 
+# Number of validators ready to asume block is available
+successCondition = 0.9
+
 # If True, print diagnostics when the block is not available
 diagnostics = False
 


### PR DESCRIPTION
Now, instead of assuming all (100%) of the samples should arrive to their destination, it checks whether a _majority_ of validators got all their expected samples. The majority threshold is a parameter given in the configuration file. In the current beacon chain specification a block is considered "finalized" after 66.6% of validators attest to it. However, I have set the success condition to 90% to be conservative.